### PR TITLE
chore: fix orchestration issue related to starting the keycloack pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Running `./deploy-terarium.sh status` will show the status of the various TERAri
 To bring the TERArium stack down, simply run `./deploy-terarium.sh down` and all the services will be torn down.
 
 ### Private Registries
-If the deployments access private registries, Kubernetes will not be able to automatically pull those images for you. To do so, a secret with the required credentials is required and used for the deployment. To do this refer to the [registry documentation](../../.github/CONTRIBUTING.md#kubernetes).
+If the deployments access private registries, Kubernetes will not be able to automatically pull those images for you. To do so, a secret with the required credentials is required and used for the deployment. To do this refer to the [registry documentation](./CONTRIBUTING.md#kubernetes).
 
 ## Theming Keycloak
 It is possible to theme different Keycloak views. To do so the new themes should be placed under `/opt/keycloak/themes/` directory. This local deployment shows and example of how to retheme the login page by loading a data image that contains the theme that is copied over to the Keycloak POD on initialization. If additional themes are made for other views the main theme image should be update as described [here](keycloak-theme/README.md).

--- a/kubernetes/local/deploy-terarium.sh
+++ b/kubernetes/local/deploy-terarium.sh
@@ -3,14 +3,6 @@
 
 if [[ ${1} == "up" ]]; then
 
-		# # Manually pulling images here, as the K8s sometimes timeout
-		# docker pull ghcr.io/unchartedsoftware/httpd-openidc:0.1.2
-		# docker pull ghcr.io/unchartedsoftware/keycloak:0.1.2
-		# docker pull ghcr.io/darpa-askem/terarium-login-theme:0.0.1
-		# docker pull ghcr.io/darpa-askem/hmi-server:dev
-		# # TODO: switch to hmi-client when image is available
-		# docker pull ghcr.io/darpa-askem/webapp:dev
-
     kubectl apply \
     -f gateway-postgres-service.yaml \
     -f gateway-postgres-deployment.yaml \
@@ -54,7 +46,24 @@ if [[ ${1} == "status" ]]; then
     exit 0
 fi
 
+if [[ ${1} == "dev" ]]; then
+
+    kubectl apply \
+    -f gateway-postgres-service.yaml \
+    -f gateway-postgres-deployment.yaml \
+    -f gateway-keycloak-realm.yaml \
+    -f gateway-keycloak-service.yaml \
+    -f gateway-keycloak-deployment.yaml \
+    -f gateway-httpd-config.yaml \
+    -f gateway-httpd-htdocs.yaml \
+    -f gateway-httpd-service.yaml \
+    -f gateway-httpd-deployment.yaml
+
+    exit 0
+fi
+
 echo "Usage:"
-echo "    ${0} up        launches the Gateway and Authentication services"
+echo "    ${0} up        launches the Gateway and Authentication services and hmi (i.e. full stack)"
 echo "    ${0} down      tears down the Gateway and Authentication services"
+echo "    ${0} dev       launches the Gateway and Authentication services"
 echo "    ${0} status    displays the status of the Gateway and Authentication services"

--- a/kubernetes/local/deploy-terarium.sh
+++ b/kubernetes/local/deploy-terarium.sh
@@ -63,7 +63,7 @@ if [[ ${1} == "dev" ]]; then
 fi
 
 echo "Usage:"
-echo "    ${0} up        launches the Gateway and Authentication services and hmi (i.e. full stack)"
-echo "    ${0} down      tears down the Gateway and Authentication services"
-echo "    ${0} dev       launches the Gateway and Authentication services"
+echo "    ${0} up        launches TERArium"
+echo "    ${0} down      tears down TERArium"
+echo "    ${0} dev       launches only the Gateway and Authentication services"
 echo "    ${0} status    displays the status of the Gateway and Authentication services"

--- a/kubernetes/local/gateway-keycloak-deployment.yaml
+++ b/kubernetes/local/gateway-keycloak-deployment.yaml
@@ -71,6 +71,8 @@ spec:
               mountPath: /data
           resources: {}
       restartPolicy: Always
+      imagePullSecrets:
+        - name: ghcr-cred
       volumes:
         - name: realm-volume
           configMap:


### PR DESCRIPTION
# Description
Upon trying to start the orchestration, I noticed some issue with starting the keycloack pod, and the proposed changes are meant to remove those issues.

Also, a "dev" option is added to start the TERArium deployment without starting the hmi client / server, which often will be launched locally by the developer!

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Resolves #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide reproduction instructions and list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

