### PR TITLE
chore: ensure the httpd session has a longer timeout (6.6 minutes) than the…

### DIFF
--- a/kubernetes/local/gateway-httpd-config.yaml
+++ b/kubernetes/local/gateway-httpd-config.yaml
@@ -30,6 +30,7 @@ data:
       OIDCScope "openid email profile"
       OIDCXForwardedHeaders X-Forwarded-Host X-Forwarded-Port X-Forwarded-Proto
       OIDCPassClaimsAs headers
+      OIDCSessionInactivityTimeout 400
 
       OIDCRemoteUserClaim sub
       OIDCPassClaimsAs environment


### PR DESCRIPTION
… keycloak session (5 minutes

# Description

Add `OIDCSessionInactivityTimeout 400` to httpd config to stop the error `no_access_token_exists` from occuring when the httpd session has timed-out before the renewal of the bearer token.

Resolves #(issue)

## Type of change

- [ √ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide reproduction instructions and list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

