### PR TITLE
feat: update deploy-terarium.sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,17 +49,11 @@ To have Kubernetes access a private container image or repository it needs to ha
 #### Create Secret
 To create the secret for kubernetes use the following command:
 ```sh
-kubectl create secret docker-registry ghcr-cred \ 
-	--docker-server=<your-registry-server> \
-	--docker-username=<your-name> \
-	--docker-password=<your-pword> \
-	--docker-email=<your-email>
+kubectl create secret docker-registry ghcr-cred --docker-server=ghcr.io --docker-password=$CR_PAT --docker-username=<your-GitHub-username>
 ```
 where:
-- `<your-registry-server>` is `ghcr.io` for the GitHub Registry
-- `<your-name>` is your GitHub username.
-- `<your-pword>` is your GitHub PAT.
-- `<your-email>` is your email (optional)
+- `<your-GitHub-username>` is your GitHub username.
+- `$CR_PAT` is your GitHub PAT.
 
 You have successfully set your credentials in the cluster as a Secret called `ghcr-cred`.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ Running `./deploy-terarium.sh status` will show the status of the various TERAri
 
 To bring the TERArium stack down, simply run `./deploy-terarium.sh down` and all the services will be torn down.
 
+To only launch the services you need:
+```shell
+$ ./deploy-terarium.sh dev               # launches only the Gateway and Authentication services"
+$ ./deploy-terarium.sh dev:hmi-server    # launches TERArium without hmi-server"
+$ ./deploy-terarium.sh dev:hmi-client    # launches TERArium without hmi-client"
+```
+
 ### Private Registries
 If the deployments access private registries, Kubernetes will not be able to automatically pull those images for you. To do so, a secret with the required credentials is required and used for the deployment. To do this refer to the [registry documentation](./CONTRIBUTING.md#kubernetes).
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ To bring the TERArium stack down, simply run `./deploy-terarium.sh down` and all
 
 To only launch the services you need:
 ```shell
-$ ./deploy-terarium.sh dev               # launches only the Gateway and Authentication services"
-$ ./deploy-terarium.sh dev:hmi-server    # launches TERArium without hmi-server"
-$ ./deploy-terarium.sh dev:hmi-client    # launches TERArium without hmi-client"
+$ ./deploy-terarium.sh dev                  # Launches only the Gateway and Authentication services
+$ ./deploy-terarium.sh dev:no-hmi-server    # Launches TERArium without the hmi-server
+$ ./deploy-terarium.sh dev:no-hmi-client    # Launches TERArium without the hmi-client
 ```
 
 ### Private Registries

--- a/kubernetes/local/deploy-terarium.sh
+++ b/kubernetes/local/deploy-terarium.sh
@@ -1,73 +1,68 @@
 #!/bin/bash
 
+function start_gateway() {
+    kubectl apply --filename 'gateway-*.yaml'
+}
 
+function start_hmi-server() {
+    # Wait for Keyclock, the hmi-server test its existence on start
+    kubectl rollout status --filename 'gateway-keycloak-*.yaml'
+    kubectl apply --filename 'hmi-server-*.yaml','mock-data-service-*.yaml'
+}
+
+function start_hmi-client() {
+    kubectl apply --filename 'hmi-client-*.yaml'
+}
+
+# launches TERArium
 if [[ ${1} == "up" ]]; then
-
-    kubectl apply \
-    -f gateway-postgres-service.yaml \
-    -f gateway-postgres-deployment.yaml \
-    -f gateway-keycloak-realm.yaml \
-    -f gateway-keycloak-service.yaml \
-    -f gateway-keycloak-deployment.yaml \
-    -f gateway-httpd-config.yaml \
-    -f gateway-httpd-htdocs.yaml \
-    -f gateway-httpd-service.yaml \
-    -f gateway-httpd-deployment.yaml \
-    -f hmi-server-service.yaml \
-    -f hmi-server-deployment.yaml \
-    -f hmi-client-service.yaml \
-    -f hmi-client-deployment.yaml \
-    -f mock-data-service-service.yaml \
-    -f mock-data-service-deployment.yaml
-
+    start_gateway && \
+    start_hmi-server && \
+    start_hmi-client
     exit 0
 fi
 
+# tears down TERArium
 if [[ ${1} == "down" ]]; then
     kubectl delete \
-    -f gateway-postgres-service.yaml \
-    -f gateway-postgres-deployment.yaml \
-    -f gateway-keycloak-realm.yaml \
-    -f gateway-keycloak-service.yaml \
-    -f gateway-keycloak-deployment.yaml \
-    -f gateway-httpd-config.yaml \
-    -f gateway-httpd-htdocs.yaml \
-    -f gateway-httpd-service.yaml \
-    -f gateway-httpd-deployment.yaml \
-    -f hmi-server-service.yaml \
-    -f hmi-server-deployment.yaml \
-    -f hmi-client-service.yaml \
-    -f hmi-client-deployment.yaml \
-    -f mock-data-service-service.yaml \
-    -f mock-data-service-deployment.yaml
-
+    --filename 'gateway-*.yaml' \
+    --filename 'hmi-server-*.yaml' \
+    --filename 'mock-data-service-*.yaml' \
+    --filename 'hmi-client-*.yaml'
     exit 0
 fi
 
+# displays the status of all services
 if [[ ${1} == "status" ]]; then
     kubectl get po,svc,configMap
-
     exit 0
 fi
 
+# launches only the Gateway and Authentication services
 if [[ ${1} == "dev" ]]; then
+    start_gateway
+    exit 0
+fi
 
-    kubectl apply \
-    -f gateway-postgres-service.yaml \
-    -f gateway-postgres-deployment.yaml \
-    -f gateway-keycloak-realm.yaml \
-    -f gateway-keycloak-service.yaml \
-    -f gateway-keycloak-deployment.yaml \
-    -f gateway-httpd-config.yaml \
-    -f gateway-httpd-htdocs.yaml \
-    -f gateway-httpd-service.yaml \
-    -f gateway-httpd-deployment.yaml
+# launches TERArium without hmi-server
+if [[ ${1} == "dev:hmi-server" ]]; then
+    start_gateway && \
+    start_hmi-client
+    exit 0
+fi
 
+# launches TERArium without hmi-client
+if [[ ${1} == "dev:hmi-client" ]]; then
+    start_gateway && \
+    start_hmi-server
     exit 0
 fi
 
 echo "Usage:"
-echo "    ${0} up        launches TERArium"
-echo "    ${0} down      tears down TERArium"
-echo "    ${0} dev       launches only the Gateway and Authentication services"
-echo "    ${0} status    displays the status of the Gateway and Authentication services"
+echo "    ${0} status            displays the status of all services"
+echo "    ${0} up                launches TERArium"
+echo "    ${0} down              tears down TERArium"
+echo "    ${0} dev               launches only the Gateway and Authentication services"
+echo "    ${0} dev:hmi-server    launches TERArium without hmi-server"
+echo "    ${0} dev:hmi-client    launches TERArium without hmi-client"
+

--- a/kubernetes/local/deploy-terarium.sh
+++ b/kubernetes/local/deploy-terarium.sh
@@ -14,7 +14,13 @@ function start_hmi-client() {
     kubectl apply --filename 'hmi-client-*.yaml'
 }
 
-# launches TERArium
+# Displays the status of all services
+if [[ ${1} == "status" ]]; then
+    kubectl get po,svc,configMap
+    exit 0
+fi
+
+# Launches TERArium
 if [[ ${1} == "up" ]]; then
     start_gateway && \
     start_hmi-server && \
@@ -22,7 +28,7 @@ if [[ ${1} == "up" ]]; then
     exit 0
 fi
 
-# tears down TERArium
+# Tears down TERArium
 if [[ ${1} == "down" ]]; then
     kubectl delete \
     --filename 'gateway-*.yaml' \
@@ -32,26 +38,20 @@ if [[ ${1} == "down" ]]; then
     exit 0
 fi
 
-# displays the status of all services
-if [[ ${1} == "status" ]]; then
-    kubectl get po,svc,configMap
-    exit 0
-fi
-
-# launches only the Gateway and Authentication services
+# Launches only the Gateway and Authentication services
 if [[ ${1} == "dev" ]]; then
     start_gateway
     exit 0
 fi
 
-# launches TERArium without hmi-server
+# Launches TERArium without the hmi-server
 if [[ ${1} == "dev:hmi-server" ]]; then
     start_gateway && \
     start_hmi-client
     exit 0
 fi
 
-# launches TERArium without hmi-client
+# Launches TERArium without the hmi-client
 if [[ ${1} == "dev:hmi-client" ]]; then
     start_gateway && \
     start_hmi-server
@@ -59,10 +59,10 @@ if [[ ${1} == "dev:hmi-client" ]]; then
 fi
 
 echo "Usage:"
-echo "    ${0} status            displays the status of all services"
-echo "    ${0} up                launches TERArium"
-echo "    ${0} down              tears down TERArium"
-echo "    ${0} dev               launches only the Gateway and Authentication services"
-echo "    ${0} dev:hmi-server    launches TERArium without hmi-server"
-echo "    ${0} dev:hmi-client    launches TERArium without hmi-client"
+echo "    ${0} status               Displays the status of all services"
+echo "    ${0} up                   Launches TERArium"
+echo "    ${0} down                 Tears down TERArium"
+echo "    ${0} dev                  Launches only the Gateway and Authentication services"
+echo "    ${0} dev:no-hmi-server    Launches TERArium without the hmi-server"
+echo "    ${0} dev:no-hmi-client    Launches TERArium without the hmi-client"
 

--- a/kubernetes/local/deploy-terarium.sh
+++ b/kubernetes/local/deploy-terarium.sh
@@ -45,14 +45,14 @@ if [[ ${1} == "dev" ]]; then
 fi
 
 # Launches TERArium without the hmi-server
-if [[ ${1} == "dev:hmi-server" ]]; then
+if [[ ${1} == "dev:no-hmi-server" ]]; then
     start_gateway && \
     start_hmi-client
     exit 0
 fi
 
 # Launches TERArium without the hmi-client
-if [[ ${1} == "dev:hmi-client" ]]; then
+if [[ ${1} == "dev:no-hmi-client" ]]; then
     start_gateway && \
     start_hmi-server
     exit 0


### PR DESCRIPTION
# Description

* Remembering how to stop a service is not really clear, and the documentation is not fully made.
* I added to more commands `dev:hmi-client` and `dev:hmi-server` to start all the TERArium services except the one named.
* I cleaned up the script:
  * use the long flags form 
  * simplify the long list of files by using `*` 
  * added comments
  * added `kubectl rollout status` to wait for keycloak to start before the `hmi-server`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

* Run the commands `dev:no-hmi-client` should start all services except `hmi-client`
* Run the commands `dev:no-hmi-server` should start all services except `hmi-server`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

