### PR TITLE
fix: use a docker image of postgres on ghcr.io so k8s is able to pull it

### DIFF
--- a/kubernetes/local/gateway-postgres-deployment.yaml
+++ b/kubernetes/local/gateway-postgres-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         software.uncharted.terarium: gateway-postgres
     spec:
       containers:
-        - image: postgres:14.4-alpine
+        - image: ghcr.io/unchartedsoftware/postgres:14.4-alpine
           name: gateway-postgres
           env:
             - name: POSTGRES_USER


### PR DESCRIPTION
# Description

This uses a docker image of Postgres stored in the GitHub docker repository. This ensures that if the image is not present on the host machine, the local k8s cluster is able to pull the image without having to create more tokens and add separate secrets.

Resolves #(issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The stack is able to start and run with the new image tag.