### PR TITLE
docs: fix link to the badge after ci refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Lint & Format](https://github.com/DARPA-ASKEM/orchestration/actions/workflows/lint_format.yaml/badge.svg)](https://github.com/DARPA-ASKEM/orchestration/actions/workflows/lint_format.yaml)
-[![Build Docker Images](https://github.com/DARPA-ASKEM/orchestration/actions/workflows/publish.yaml/badge.svg)](https://github.com/DARPA-ASKEM/orchestration/actions/workflows/publish.yaml)
+[![Lint & Format](https://github.com/DARPA-ASKEM/orchestration/actions/workflows/lint.yaml/badge.svg?branch=main)](https://github.com/DARPA-ASKEM/orchestration/actions/workflows/lint_format.yaml)
+[![Build Docker Images](https://github.com/DARPA-ASKEM/orchestration/actions/workflows/publish.yaml/badge.svg?branch=main)](https://github.com/DARPA-ASKEM/orchestration/actions/workflows/publish.yaml)
 # Orchestration
 Scripts and deployment information needed to setup and run TERArium
 


### PR DESCRIPTION
# Description

Fixing the link to the lint badge as the underlying CI file has been renamed

Resolves #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

