### PR TITLE
fix: add credentials for document service

### DIFF
--- a/kubernetes/local/document-service-deployment.yaml
+++ b/kubernetes/local/document-service-deployment.yaml
@@ -23,5 +23,7 @@ spec:
           ports:
             - containerPort: 3030
           resources: {}
+      imagePullSecrets:
+        - name: ghcr-cred
       restartPolicy: Always
 status: {}


### PR DESCRIPTION
# Description

Add `ghcr-cred` to the `document-service` deployment script.