### PR TITLE
docs: update README.md to start local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Or for the _Data Service_ `./deploy-terarium.sh stop data-service`.
 
 To only launch the services you need:
 ```shell
-$ ./deploy-terarium.sh dev                  # Launches TERArium without the hmi-server and hmi-client
-$ ./deploy-terarium.sh stop hmi-client      # Stop the hmi-client
+$ ./deploy-terarium.sh up                  # Launches TERArium
+$ ./deploy-terarium.sh stop hmi-client     # Stop the hmi-client
 ```
 
 ### Private Registries

--- a/kubernetes/local/deploy-terarium.sh
+++ b/kubernetes/local/deploy-terarium.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 function start_gateway() {
-    kubectl apply --filename 'gateway-*.yaml'
+    kubectl apply --filename 'gateway-httpd-*.yaml'
+    kubectl apply --filename 'gateway-postgres-*.yaml'
+
+    # Wait for the Database to be setup, keycloak needs it
+    kubectl rollout status --filename 'gateway-postgres-*.yaml'
+    kubectl apply --filename 'gateway-keycloak-*.yaml'
 }
 
 function start_db() {


### PR DESCRIPTION
# Description

* Remove the confusing `./deploy-terarium.sh dev`
* Add a step to wait for DB to be setup before starting keycloack