### PR TITLE
feat: add a postgres for the terrarium application

### DIFF
--- a/kubernetes/local/deploy-terarium.sh
+++ b/kubernetes/local/deploy-terarium.sh
@@ -7,6 +7,7 @@ function start_gateway() {
 function start_db() {
 	kubectl apply --filename 'data-service-postgres-*.yaml'
 	kubectl apply --filename 'data-service-graphdb-*.yaml'
+	kubectl apply --filename 'hmi-postgres-*.yaml'
 }
 
 function start_data-service() {

--- a/kubernetes/local/hmi-postgres-deployment.yaml
+++ b/kubernetes/local/hmi-postgres-deployment.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    software.uncharted.terarium: hmi-postgres
+  name: hmi-postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      software.uncharted.terarium: hmi-postgres
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        software.uncharted.terarium: hmi-postgres
+    spec:
+      containers:
+        - image: ghcr.io/darpa-askem/postgres:15.1
+          name: hmi-postgres
+          env:
+            - name: POSTGRES_USER
+              value: terarium
+            - name: POSTGRES_PASSWORD
+              value: terarium123
+            - name: POSTGRES_DB
+              value: terarium
+          ports:
+            - containerPort: 5432
+          resources: {}
+      imagePullSecrets:
+        - name: ghcr-cred
+      restartPolicy: Always
+status: {}

--- a/kubernetes/local/hmi-postgres-service.yaml
+++ b/kubernetes/local/hmi-postgres-service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hmi-postgres
+spec:
+  ports:
+    - name: 5021-tcp
+      port: 5021
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    software.uncharted.terarium: hmi-postgres
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/kubernetes/local/hmi-server-deployment.yaml
+++ b/kubernetes/local/hmi-server-deployment.yaml
@@ -35,6 +35,14 @@ spec:
               value: host.docker.internal
             - name: keycloak-service-port
               value: :8079
+            - name: terarium-db-user
+              value: terarium
+            - name: terarium-db-password
+              value: terarium123
+            - name: terarium-db-host
+              value: host.docker.internal
+            - name: terarium-db-port
+              value: :5021
           ports:
             - containerPort: 3000
           resources: {}

--- a/kubernetes/production/hmi-server-deployment.yaml
+++ b/kubernetes/production/hmi-server-deployment.yaml
@@ -39,6 +39,26 @@ spec:
                 secretKeyRef:
                   name: oidc
                   key: client_secret
+            - name: terarium-db-host
+              valueFrom:
+                secretKeyRef:
+                  name: rds-creds
+                  key: url
+            - name: terarium-db-port
+              valueFrom:
+                secretKeyRef:
+                  name: rds-creds
+                  key: port
+            - name: terarium-db-user
+              valueFrom:
+                secretKeyRef:
+                  name: rds-creds
+                  key: username
+            - name: terarium-db-password
+              valueFrom:
+                secretKeyRef:
+                  name: rds-creds
+                  key: password
           ports:
             - containerPort: 8080
           resources: {}

--- a/kubernetes/staging/hmi-server-deployment.yaml
+++ b/kubernetes/staging/hmi-server-deployment.yaml
@@ -39,6 +39,26 @@ spec:
                 secretKeyRef:
                   name: oidc
                   key: client_secret
+            - name: terarium-db-host
+              valueFrom:
+                secretKeyRef:
+                  name: rds-creds
+                  key: url
+            - name: terarium-db-port
+              valueFrom:
+                secretKeyRef:
+                  name: rds-creds
+                  key: port
+            - name: terarium-db-user
+              valueFrom:
+                secretKeyRef:
+                  name: rds-creds
+                  key: username
+            - name: terarium-db-password
+              valueFrom:
+                secretKeyRef:
+                  name: rds-creds
+                  key: password
           ports:
             - containerPort: 8080
           resources: {}


### PR DESCRIPTION
This adds a local postgres and provides the correct environment for connecting to RDS in staging and production via the hmi-server.  

Corresponding PR: https://github.com/DARPA-ASKEM/TERArium/pull/482