### PR TITLE
WIP: change admin url

### DIFF
--- a/kubernetes/overlays/prod/base/gateway/gateway-keycloak-deployment.yaml
+++ b/kubernetes/overlays/prod/base/gateway/gateway-keycloak-deployment.yaml
@@ -41,8 +41,6 @@ spec:
                   key: password
             - name: KC_HOSTNAME_PORT
               value: "443"
-            - name: KC_HOSTNAME_ADMIN_URL
-              value: https://localhost:8443
             - name: KC_HOSTNAME_PATH
               value: /auth
             - name: KC_HTTP_ENABLED

--- a/kubernetes/overlays/prod/base/gateway/gateway-keycloak-service.yaml
+++ b/kubernetes/overlays/prod/base/gateway/gateway-keycloak-service.yaml
@@ -15,5 +15,6 @@ spec:
       targetPort: 8443
   selector:
     software.uncharted.terarium/name: gateway-keycloak
+  type: NodePort
 status:
   loadBalancer: {}

--- a/kubernetes/overlays/prod/overlays/askem-production/gateway/gateway-keycloak-deployment.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-production/gateway/gateway-keycloak-deployment.yaml
@@ -11,3 +11,5 @@ spec:
           env:
             - name: KC_HOSTNAME
               value: app.terarium.ai
+            - name: KC_HOSTNAME_ADMIN_URL
+              value: https://admin.terarium.ai

--- a/kubernetes/overlays/prod/overlays/askem-production/gateway/gateway-keycloak-ingress.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-production/gateway/gateway-keycloak-ingress.yaml
@@ -22,4 +22,4 @@ spec:
               service:
                 name: gateway-keycloak
                 port:
-                  number: 8079
+                  number: 443

--- a/kubernetes/overlays/prod/overlays/askem-staging/gateway/gateway-keycloak-deployment.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-staging/gateway/gateway-keycloak-deployment.yaml
@@ -11,3 +11,5 @@ spec:
           env:
             - name: KC_HOSTNAME
               value: app.staging.terarium.ai
+            - name: KC_HOSTNAME_ADMIN_URL
+              value: https://admin.staging.terarium.ai

--- a/kubernetes/overlays/prod/overlays/askem-staging/gateway/gateway-keycloak-ingress.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-staging/gateway/gateway-keycloak-ingress.yaml
@@ -22,4 +22,5 @@ spec:
               service:
                 name: gateway-keycloak
                 port:
-                  number: 8079
+                  number: 443
+


### PR DESCRIPTION
# Description

This might be all that is needed to make the admin[.staging].terarium.ai work.

However, it needs the ELB for admin[.staging].terarium.ai to point at 443 (using TLS) got the gateway-keycloak, until that is altered I cannot test this.

Resolves #(issue)

Accessing the admin keycloak via SSH KubeCtl tunnel