### PR TITLE
chore: add skema to staging and prod kube cluster

### DIFF
--- a/kubernetes/base/services/skema/kustomization.yaml
+++ b/kubernetes/base/services/skema/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - skema-rs-deployment.yaml
+  - skema-rs-service.yaml
+  - skema-py-deployment.yaml
+  - skema-py-service.yaml
+  - skema-memgraph-deployment.yaml
+  - skema-memgraph-service.yaml

--- a/kubernetes/base/services/skema/skema-memgraph-deployment.yaml
+++ b/kubernetes/base/services/skema/skema-memgraph-deployment.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    software.uncharted.terarium/name: skema-memgraph
+  name: skema-memgraph
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      software.uncharted.terarium/name: skema-memgraph
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        software.uncharted.terarium/component: skema
+        software.uncharted.terarium/environment: dev
+        software.uncharted.terarium/tier: services
+        software.uncharted.terarium/name: skema-memgraph
+    spec:
+      containers:
+        - image: skema-memgraph-image
+          name: skema-memgraph
+          command: ['/usr/bin/supervisord']
+          ports:
+            - containerPort: 7687
+            - containerPort: 3000
+            - containerPort: 7444
+          resources: {}
+      imagePullSecrets:
+        - name: ghcr-cred
+      restartPolicy: Always
+status: {}

--- a/kubernetes/base/services/skema/skema-memgraph-service.yaml
+++ b/kubernetes/base/services/skema/skema-memgraph-service.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    software.uncharted.terarium/component: skema
+    software.uncharted.terarium/environment: dev
+    software.uncharted.terarium/tier: services
+  name: skema-memgraph
+spec:
+  ports:
+    - name: 7687-tcp
+      port: 7687
+      protocol: TCP
+      targetPort: 7687
+    - name: 7444-tcp
+      port: 7444
+      protocol: TCP
+      targetPort: 7444
+    - name: 3111-tcp
+      port: 3111
+      protocol: TCP
+      targetPort: 3000
+  selector:
+    software.uncharted.terarium/name: skema-memgraph
+status:
+  loadBalancer: {}

--- a/kubernetes/base/services/skema/skema-py-deployment.yaml
+++ b/kubernetes/base/services/skema/skema-py-deployment.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    software.uncharted.terarium/name: skema-py
+  name: skema-py
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      software.uncharted.terarium/name: skema-py
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        software.uncharted.terarium/component: skema
+        software.uncharted.terarium/environment: dev
+        software.uncharted.terarium/tier: services
+        software.uncharted.terarium/name: skema-py
+    spec:
+      containers:
+        - image: skema-py-image
+          name: skema-py
+          command: ['uvicorn']
+          args: ['server:app', '--host', '0.0.0.0']
+          ports:
+            - containerPort: 8000
+          resources: {}
+      imagePullSecrets:
+        - name: ghcr-cred
+      restartPolicy: Always
+status: {}

--- a/kubernetes/base/services/skema/skema-py-service.yaml
+++ b/kubernetes/base/services/skema/skema-py-service.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    software.uncharted.terarium/component: skema
+    software.uncharted.terarium/environment: dev
+    software.uncharted.terarium/tier: services
+  name: skema-py
+spec:
+  type: NodePort
+  ports:
+    - name: 4041-tcp
+      port: 4041
+      protocol: TCP
+      targetPort: 8000
+  selector:
+    software.uncharted.terarium/name: skema-py
+status:
+  loadBalancer: {}

--- a/kubernetes/base/services/skema/skema-rs-deployment.yaml
+++ b/kubernetes/base/services/skema/skema-rs-deployment.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    software.uncharted.terarium/name: skema-rs
+  name: skema-rs
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      software.uncharted.terarium/name: skema-rs
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        software.uncharted.terarium/component: skema
+        software.uncharted.terarium/environment: dev
+        software.uncharted.terarium/tier: services
+        software.uncharted.terarium/name: skema-rs
+    spec:
+      containers:
+        - image: skema-rs-image
+          name: skema-rs
+          command: ['cargo']
+          args: ['run', '--release', '--bin', 'skema_service', '--', '--host', '0.0.0.0', '--db-host', 'skema-memgraph']
+          ports:
+            - containerPort: 8080
+          resources: {}
+      imagePullSecrets:
+        - name: ghcr-cred
+      restartPolicy: Always
+status: {}

--- a/kubernetes/base/services/skema/skema-rs-service.yaml
+++ b/kubernetes/base/services/skema/skema-rs-service.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    software.uncharted.terarium/component: skema
+    software.uncharted.terarium/environment: dev
+    software.uncharted.terarium/tier: services
+  name: skema-rs
+spec:
+  type: NodePort
+  ports:
+    - name: 4040-tcp
+      port: 4040
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    software.uncharted.terarium/name: skema-rs
+status:
+  loadBalancer: {}

--- a/kubernetes/overlays/prod/base/hmi/hmi-server-deployment.yaml
+++ b/kubernetes/overlays/prod/base/hmi/hmi-server-deployment.yaml
@@ -11,6 +11,10 @@ spec:
           env:
             - name: data-service
               value: data-service
+            - name: SKEMA_MP_REST_URL
+              value: "http://skema-py:4041"
+            - name: SKEMA_RUST_MP_REST_URL
+              value: "http://skema-rs:4040"
             - name: keycloak-service-protocol
               value: https
             - name: keycloak-service-fqdn

--- a/kubernetes/overlays/prod/base/kustomization.yaml
+++ b/kubernetes/overlays/prod/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../../base/hmi/server
   - ../../../base/services/data-service
   - ../../../base/services/model-service
+  - ../../../base/services/skema
   - gateway/gateway-keycloak-service.yaml
 patchesStrategicMerge:
   - gateway/gateway-httpd-deployment.yaml

--- a/kubernetes/overlays/prod/overlays/askem-production/kustomization.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-production/kustomization.yaml
@@ -52,3 +52,12 @@ images:
   - name: data-service-graphdb-image
     newName: ghcr.io/darpa-askem/data-service-graphdb
     newTag: 5.3.0.3
+  - name: skema-py-image
+    newName: ghcr.io/darpa-askem/skema-py
+    newTag: 0.0.1
+  - name: skema-rs-image
+    newName: ghcr.io/darpa-askem/skema-rs
+    newTag: 0.0.1
+  - name: skema-memgraph-image
+    newName: ghcr.io/darpa-askem/memgraph-platform
+    newTag: 2.6.5-memgraph2.5.2-lab2.4.0-mage1.6

--- a/kubernetes/overlays/prod/overlays/askem-staging/kustomization.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-staging/kustomization.yaml
@@ -53,3 +53,13 @@ images:
   - name: data-service-graphdb-image
     newName: ghcr.io/darpa-askem/data-service-graphdb
     newTag: 5.3.0.3
+
+  - name: skema-py-image
+    newName: ghcr.io/darpa-askem/skema-py
+    newTag: latest
+  - name: skema-rs-image
+    newName: ghcr.io/darpa-askem/skema-rs
+    newTag: latest
+  - name: skema-memgraph-image
+    newName: ghcr.io/darpa-askem/memgraph-platform
+    newTag: 2.6.5-memgraph2.5.2-lab2.4.0-mage1.6

--- a/kubernetes/overlays/prod/overlays/askem-staging/services/skema-py-ingress.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-staging/services/skema-py-ingress.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: terarium
+  name: skema-py
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: instance
+    alb.ingress.kubernetes.io/security-groups: askem-staging-web-private
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '443'
+spec:
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: skema-py
+                port:
+                  number: 4041
+  tls:
+    - hosts:
+        - "skema-py.staging.terarium.ai"

--- a/kubernetes/overlays/prod/overlays/askem-staging/services/skema-rs-ingress.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-staging/services/skema-rs-ingress.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: terarium
+  name: skema-rs
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: instance
+    alb.ingress.kubernetes.io/security-groups: askem-staging-web-private
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '443'
+spec:
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: skema-rs
+                port:
+                  number: 4040
+  tls:
+    - hosts:
+        - "skema-rs.staging.terarium.ai"


### PR DESCRIPTION
This adds the skema components to the staging and production kubernetes cluster.  This is currently deploy and configured on staging. We add an ingress so that local development can use this service without needing to run the components locally.  

The main components (in docker-compose form):
```yaml
services:
  skema-py:
    image: skema-py:latest
    ports:
    - "8008:8000"
    command: ["uvicorn", "server:app", "--host", "0.0.0.0"]
  skema-rs:
    image: skema-rs:latest
    entrypoint: cargo run --release --bin skema_service -- --host 0.0.0.0 --db-host database
    ports:
      - "8080:8080"
  database:
    image: "memgraph/memgraph-platform"
    ports:
      - "7687:7687"
      - "3000:3000"
      - "7444:7444"
    entrypoint: ["/usr/bin/supervisord"]
```

These three services have been configured in `base` but only added to the customize for the `prod` profile.  This is to ensure they do not run locally (intentional).  A followup PR in the Terarium repo will set the correct URLs to point at the ingresses created in the staging environment.  In staging and production, we use internal DNS to reference the components via the following environment overrides:
```yaml
spec:
  template:
    spec:
      containers:
        - name: hmi-server
            - name: SKEMA_MP_REST_URL
              value: "http://skema-py:4041"
            - name: SKEMA_RUST_MP_REST_URL
              value: "http://skema-rs:4040"
```