### PR TITLE
fix: fix model-service being unreachable in staging and production

### DIFF
--- a/kubernetes/overlays/prod/base/hmi/hmi-server-deployment.yaml
+++ b/kubernetes/overlays/prod/base/hmi/hmi-server-deployment.yaml
@@ -11,6 +11,8 @@ spec:
           env:
             - name: data-service
               value: data-service
+            - name: model-service
+              value: model-service
             - name: SKEMA_MP_REST_URL
               value: "http://skema-py:4041"
             - name: SKEMA_RUST_MP_REST_URL


### PR DESCRIPTION
Ensure we provide the url for the model service in the base hmi-deployment manifest.

This fix is already deployed to `staging.terarium.ai` but needs to be applied to production.