### PR TITLE
feat: add missing realm details needed for hmi-latest

### DIFF
--- a/kubernetes/overlays/prod/overlays/askem-staging/gateway/gateway-httpd-deployment.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-staging/gateway/gateway-httpd-deployment.yaml
@@ -9,8 +9,14 @@ spec:
       containers:
         - name: gateway-httpd
           env:
+            - name: REALM
+              value: Uncharted
+            - name: KEYCLOAK_ADMIN_FQDN
+              value: localhost
             - name: SERVICE_FQDN
               value: app.staging.terarium.ai
+            - name: ADMIN_KEYCLOAK_SERVICE_URL
+              value: http://gateway-admin-keycloak:8080/adminapi/
       hostAliases:
         - ip: "127.0.0.1"
           hostnames:

--- a/kubernetes/overlays/prod/overlays/askem-staging/hmi/hmi-server-deployment.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-staging/hmi/hmi-server-deployment.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hmi-server
+spec:
+  template:
+    spec:
+      containers:
+        - name: hmi-server
+          env:
+            - name: realm
+              value: Uncharted

--- a/kubernetes/overlays/prod/overlays/askem-staging/kustomization.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-staging/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 patchesStrategicMerge:
   - gateway/gateway-httpd-deployment.yaml
   - gateway/gateway-keycloak-deployment.yaml
+  - hmi/hmi-server-deployment.yaml
 configMapGenerator:
   - files:
       - gateway/keycloak/realm/Uncharted-users-0.json

--- a/kubernetes/production_deploy.sh
+++ b/kubernetes/production_deploy.sh
@@ -97,7 +97,7 @@ staging)
 	SECRET_FILES+=("overlays/prod/base/gateway/keycloak/realm/*.json" "overlays/prod/overlays/askem-staging/gateway/keycloak/realm/*.json")
 	SECRET_FILES+=("overlays/prod/overlays/askem-staging/check-latest/check-latest-rsa" "overlays/prod/overlays/askem-staging/check-latest/secrets.yaml")
 	KUSTOMIZATION=overlays/prod/overlays/askem-staging
-	KUBECTL_CMD="ssh uncharted-askem-prod-askem-staging-kube-manager-1 sudo kubectl"
+	KUBECTL_CMD="ssh uncharted-askem-prod-askem-staging-kube-manager-2 sudo kubectl"
 	;;
 production)
 	SECRET_FILES+=("overlays/prod/base/gateway/certificates/cert.pem" "overlays/prod/base/gateway/certificates/key.pem")


### PR DESCRIPTION
# Description

`hmi-server` LASTEST needs environment variable `realm` set

Caveats: currently set to `Uncharted` as staging is still using that realm
Running the deployment puts gateway-admin-keycloak into the deployed stack, however, it is not ready for prime time - manually removing it (in case one deploys to staging (or production))

Resolves #(issue)
