### PR TITLE
chore: add an ingress for model service and ensure it runs as a node port

### DIFF
--- a/kubernetes/base/services/model-service/model-service-service.yaml
+++ b/kubernetes/base/services/model-service/model-service-service.yaml
@@ -8,6 +8,7 @@ metadata:
     software.uncharted.terarium/tier: services
   name: model-service
 spec:
+  type: NodePort
   ports:
     - name: 3010-tcp
       port: 3010

--- a/kubernetes/overlays/prod/overlays/askem-staging/services/model-service-ingress.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-staging/services/model-service-ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: terarium
-  name: data-service
+  name: model-service
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: instance

--- a/kubernetes/overlays/prod/overlays/askem-staging/services/model-service-ingress.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-staging/services/model-service-ingress.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: terarium
+  name: data-service
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: instance
+    alb.ingress.kubernetes.io/security-groups: askem-staging-web-private
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '443'
+spec:
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: model-service
+                port:
+                  number: 3010
+  tls:
+    - hosts:
+        - "model-service.staging.terarium.ai"


### PR DESCRIPTION
This was missing from a previous PR that moved model-service into staging for local deployment.  This ensures the service runs as a `NodePort` and also that it has an ingress available to configure DNS