### PR TITLE
chore: updating docs for ARM64 processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,16 @@ See [Uncharted-Auth](https://github.com/unchartedsoftware/uncharted-auth) for de
 ### Install Ansible
 Required to encrypt/decrypt secrets.
 
+x86/64 processors:
 ```shell
 brew install ansible
 ```
+
+ARM64 processors:
+```shell
+arch -arm64 brew install ansible
+```
+
 
 ### Enabling Kubernetes
 


### PR DESCRIPTION
Specialized ansible install version for arm64 processors

# Description

can't use x86 version

Resolves #noissue
