### PR TITLE
feat: script to do optional local deployment

### DIFF
--- a/kubernetes/dev_deploy.sh
+++ b/kubernetes/dev_deploy.sh
@@ -154,6 +154,16 @@ up)
 				kubectl kustomize ./overlays/dev/local/services/pyciemss-service | kubectl apply --filename -
 				;;
 
+			funman)
+				echo "Launching FUNMAN on localhost..."
+				kubectl kustomize ./overlays/dev/local/services/funman | kubectl apply --filename -
+				;;
+
+			jupyter-llm)
+				echo "Launching JUPYTER-LLM on localhost..."
+				kubectl kustomize ./overlays/dev/local/services/jupyter-llm | kubectl apply --filename -
+				;;
+
 			model-service)
 				echo "Launching MODEL SERVICE on localhost..."
 				kubectl kustomize ./overlays/dev/local/services/model-service | kubectl apply --filename -
@@ -228,6 +238,16 @@ down)
 			pyciemss-service)
 				echo "Tearing down CIEMSS on localhost..."
 				kubectl kustomize ./overlays/dev/local/services/pyciemss-service | kubectl delete --filename -
+				;;
+		
+			funman)
+				echo "Launching FUNMAN on localhost..."
+				kubectl kustomize ./overlays/dev/local/services/funman | kubectl delete --filename -
+				;;
+
+			jupyter-llm)
+				echo "Launching JUPYTER-LLM on localhost..."
+				kubectl kustomize ./overlays/dev/local/services/jupyter-llm | kubectl delete --filename -
 				;;
 
 			model-service)

--- a/kubernetes/dev_deploy.sh
+++ b/kubernetes/dev_deploy.sh
@@ -120,6 +120,8 @@ up)
 		echo "Launching TERArium on localhost..."
 		kubectl kustomize ./overlays/dev/local | kubectl apply --filename -
 	else
+		kubectl kustomize ./overlays/dev/local/secrets | kubectl apply --filename -
+
 		for SERVICE in "${SERVICES[@]}"; do
 			case ${SERVICE} in
 			hmi-client)
@@ -147,6 +149,11 @@ up)
 				kubectl kustomize ./overlays/dev/local/services/data-service | kubectl apply --filename -
 				;;
 
+			pyciemss-service)
+				echo "Launching CIEMSS on localhost..."
+				kubectl kustomize ./overlays/dev/local/services/pyciemss-service | kubectl apply --filename -
+				;;
+
 			model-service)
 				echo "Launching MODEL SERVICE on localhost..."
 				kubectl kustomize ./overlays/dev/local/services/model-service | kubectl apply --filename -
@@ -167,6 +174,11 @@ up)
 				kubectl kustomize ./overlays/dev/local/gateway | kubectl apply --filename -
 				;;
 
+			redis)
+				echo "Launching REDIS on localhost..."
+				kubectl kustomize ./overlays/dev/local/services/redis | kubectl apply --filename -
+				;;
+
 			*)
 				echo "'${SERVICE}' is not a valid service. Please specify a valid service."
 				;;
@@ -184,6 +196,8 @@ down)
 		echo "Launching TERArium on localhost..."
 		kubectl kustomize ./overlays/dev/local | kubectl delete --filename -
 	else
+		kubectl kustomize ./overlays/dev/local/secrets | kubectl apply --filename -
+
 		for SERVICE in "${SERVICES[@]}"; do
 			case ${SERVICE} in
 			hmi-client)
@@ -211,6 +225,11 @@ down)
 				kubectl kustomize ./overlays/dev/local/services/data-service | kubectl delete --filename -
 				;;
 
+			pyciemss-service)
+				echo "Tearing down CIEMSS on localhost..."
+				kubectl kustomize ./overlays/dev/local/services/pyciemss-service | kubectl delete --filename -
+				;;
+
 			model-service)
 				echo "Tearing down MODEL SERVICE on localhost..."
 				kubectl kustomize ./overlays/dev/local/services/model-service | kubectl delete --filename -
@@ -230,6 +249,12 @@ down)
 				echo "Tearing down GATEWAY on localhost..."
 				kubectl kustomize ./overlays/dev/local/gateway | kubectl delete --filename -
 				;;
+
+			redis)
+				echo "Tearing down redis on localhost..."
+				kubectl kustomize ./overlays/dev/local/services/redis | kubectl delete --filename -
+				;;
+
 
 			"")
 				echo "Tearing down TERArium on localhost..."
@@ -281,7 +306,7 @@ help)
   OPTIONS include
       -h | --help            Display this help
       -o | --override        Override HOST_ADDRESS with Mac's IP address
-      -u | --use ADDRESS     Use ADDRESS as HOST_ADDRESS       
+      -u | --use ADDRESS     Use ADDRESS as HOST_ADDRESS
 			"
 	;;
 esac

--- a/kubernetes/overlays/dev/local/secrets/kustomization.yaml
+++ b/kubernetes/overlays/dev/local/secrets/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - secrets-xdd-api-key.yaml
+  - secrets-adobe-api-key.yaml
+  - secrets-es-creds.yaml
+  - secrets-data-service-s3.yaml
+  - secrets-openai-key.yaml


### PR DESCRIPTION
### Summary
Allow individual services to be deployed, as opposed to bring everything up and selectively taking down services. This should avoid the initial memory surge needed to bring up the entire dev tech stack.