### PR TITLE
fix: make timeout longer for long running api-endpoints

### DIFF
--- a/kubernetes/base/gateway/httpd/config-locations/api.conf
+++ b/kubernetes/base/gateway/httpd/config-locations/api.conf
@@ -1,5 +1,5 @@
 <Location /api/>
-    ProxyPass ${LOCATION_API_URL} timeout=10 retry=0 keepalive=On
+    ProxyPass ${LOCATION_API_URL} timeout=25 retry=0 keepalive=On
     ProxyPassReverse ${LOCATION_API_URL}
 
     AuthType openid-connect


### PR DESCRIPTION
### Summary
Bandaid solution to get around the /api/home endpoint taking a very long time.

Note it is not completely clear what the /api/home endpoint should actually be doing, we stuffed quite a few temporary experiments and hacks in there.