### PR TITLE
rename extraction service/worker to ta1 service

### DIFF
--- a/kubernetes/base/services/extraction-service/kustomization.yaml
+++ b/kubernetes/base/services/extraction-service/kustomization.yaml
@@ -1,7 +1,0 @@
----
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - extraction-api-service.yaml
-  - extraction-api-deployment.yaml
-  - extraction-worker-deployment.yaml

--- a/kubernetes/base/services/ta1-service/kustomization.yaml
+++ b/kubernetes/base/services/ta1-service/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ta1-service-api.yaml
+  - ta1-service-api-deployment.yaml
+  - ta1-service-worker-deployment.yaml

--- a/kubernetes/base/services/ta1-service/ta1-service-api-deployment.yaml
+++ b/kubernetes/base/services/ta1-service/ta1-service-api-deployment.yaml
@@ -2,27 +2,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: extraction-service-api
+  name: ta1-service-api
   labels:
-    software.uncharted.terarium/name: extraction-service-api
+    software.uncharted.terarium/name: ta1-service-api
     software.uncharted.terarium/component: api
-    software.uncharted.terarium/service: extraction-service
+    software.uncharted.terarium/service: ta1-service
     software.uncharted.terarium/part-of: services
 spec:
   replicas: 1
   selector:
     matchLabels:
-      software.uncharted.terarium/name: extraction-service-api
-  strategy:
+      software.uncharted.terarium/name: ta1-service-api
     type: Recreate
+  strategy:
   template:
     metadata:
       labels:
-        software.uncharted.terarium/name: extraction-service-api
+        software.uncharted.terarium/name: ta1-service-api
     spec:
       containers:
-        - name: extraction-service-api
-          image: extraction-service-api-image
+        - name: ta1-service-api
+          image: ta1-service-api-image
           ports:
             - containerPort: 8000
           resources: {}

--- a/kubernetes/base/services/ta1-service/ta1-service-api.yaml
+++ b/kubernetes/base/services/ta1-service/ta1-service-api.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: extraction-service-api
+  name: ta1-service-api
   labels:
-    software.uncharted.terarium/name: extraction-service-api
+    software.uncharted.terarium/name: ta1-service-api
     software.uncharted.terarium/component: api
-    software.uncharted.terarium/service: extraction-service
+    software.uncharted.terarium/service: ta1-service
     software.uncharted.terarium/part-of: services
   annotations:
     alb.ingress.kubernetes.io/healthcheck-path: '/ping'
@@ -17,6 +17,6 @@ spec:
       protocol: TCP
       targetPort: 8000
   selector:
-    software.uncharted.terarium/name: extraction-service-api
+    software.uncharted.terarium/name: ta1-service-api
 status:
   loadBalancer: {}

--- a/kubernetes/base/services/ta1-service/ta1-service-worker-deployment.yaml
+++ b/kubernetes/base/services/ta1-service/ta1-service-worker-deployment.yaml
@@ -2,27 +2,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: extraction-service-worker
+  name: ta1-service-worker
   labels:
-    software.uncharted.terarium/name: extraction-service-worker
+    software.uncharted.terarium/name: ta1-service-worker
     software.uncharted.terarium/component: worker
-    software.uncharted.terarium/service: extraction-service
+    software.uncharted.terarium/service: ta1-service
     software.uncharted.terarium/part-of: services
 spec:
   replicas: 1
   selector:
     matchLabels:
-      software.uncharted.terarium/name: extraction-service-worker
+      software.uncharted.terarium/name: ta1-service-worker
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        software.uncharted.terarium/name: extraction-service-worker
+        software.uncharted.terarium/name: ta1-service-worker
     spec:
       containers:
-        - name: extraction-service-worker
-          image: extraction-service-worker-image
+        - name: ta1-service-worker
+          image: ta1-service-worker-image
           ports:
             - containerPort: 8080
           resources: {}


### PR DESCRIPTION
Renaming of deployment code for `extraction-service` to `ta1-service`. 

Note that this is done on the builds on the `ta1-service` repo so this _ought to_ work but I'm no expert in this deployment setup.