### PR TITLE
1704 task clean dependencies 1

### DIFF
--- a/kubernetes/overlays/dev/local/hmi/server/hmi-server-deployment.yaml
+++ b/kubernetes/overlays/dev/local/hmi/server/hmi-server-deployment.yaml
@@ -22,7 +22,7 @@ spec:
             - name: keycloak-service-fqdn
               value: $(LOCALHOST)
             - name: keycloak-service-port
-              value: :8079
+              value: "8079"
             - name: terarium-db-user
               value: terarium
             - name: terarium-db-password

--- a/kubernetes/overlays/dev/local/hmi/server/hmi-server-deployment.yaml
+++ b/kubernetes/overlays/dev/local/hmi/server/hmi-server-deployment.yaml
@@ -49,38 +49,3 @@ spec:
                 secretKeyRef:
                   name: xdd-api-key
                   key: eskey
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: data-service-s3
-                  key: aws-access-key-id
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: data-service-s3
-                  key: aws-secret-access-key
-            - name: AWS_REGION
-              valueFrom:
-                secretKeyRef:
-                  name: data-service-s3
-                  key: aws-region
-            - name: S3_BUCKET
-              valueFrom:
-                secretKeyRef:
-                  name: data-service-s3
-                  key: aws-dataset-bucket
-            - name: S3_DATASET_PATH
-              valueFrom:
-                secretKeyRef:
-                  name: data-service-s3
-                  key: aws-dataset-path
-            - name: S3_ARTIFACT_PATH
-              valueFrom:
-                secretKeyRef:
-                  name: data-service-s3
-                  key: aws-artifact-path
-            - name: S3_RESULTS_PATH
-              valueFrom:
-                secretKeyRef:
-                  name: data-service-s3
-                  key: aws-results-path

--- a/kubernetes/overlays/prod/base/hmi/server/hmi-server-deployment.yaml
+++ b/kubernetes/overlays/prod/base/hmi/server/hmi-server-deployment.yaml
@@ -79,38 +79,3 @@ spec:
                 secretKeyRef:
                   name: xdd-api-key
                   key: eskey
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: data-service-s3
-                  key: aws-access-key-id
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: data-service-s3
-                  key: aws-secret-access-key
-            - name: AWS_REGION
-              valueFrom:
-                secretKeyRef:
-                  name: data-service-s3
-                  key: aws-region
-            - name: S3_BUCKET
-              valueFrom:
-                secretKeyRef:
-                  name: data-service-s3
-                  key: aws-dataset-bucket
-            - name: S3_DATASET_PATH
-              valueFrom:
-                secretKeyRef:
-                  name: data-service-s3
-                  key: aws-dataset-path
-            - name: S3_ARTIFACT_PATH
-              valueFrom:
-                secretKeyRef:
-                  name: data-service-s3
-                  key: aws-artifact-path
-            - name: S3_RESULTS_PATH
-              valueFrom:
-                secretKeyRef:
-                  name: data-service-s3
-                  key: aws-results-path


### PR DESCRIPTION
# Description

* Removing AWS secrets from hmi-server's deployment as its no longer needed. 
* Fixing reserved character combo `::` in terarium's `application.properties`

Note this PR must be merged around the same time as https://github.com/DARPA-ASKEM/Terarium/pull/1716

Resolves #1704
