### PR TITLE
Fix simulation-service env var names

### DIFF
--- a/kubernetes/overlays/dev/local/gateway/configmap/host-mac.yaml
+++ b/kubernetes/overlays/dev/local/gateway/configmap/host-mac.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: gateway-host
-data:
-  host_api: "host.docker.internal:3000"
-  host_app: "host.docker.internal:8080"

--- a/kubernetes/overlays/dev/local/gateway/configmap/host-mac.yaml
+++ b/kubernetes/overlays/dev/local/gateway/configmap/host-mac.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gateway-host
+data:
+  host_api: "host.docker.internal:3000"
+  host_app: "host.docker.internal:8080"

--- a/kubernetes/overlays/prod/base/services/simulation-service/simulation-service-deployment.yaml
+++ b/kubernetes/overlays/prod/base/services/simulation-service/simulation-service-deployment.yaml
@@ -14,7 +14,7 @@ spec:
             - name: SIMSERVICE_TDS_URL
               value: http://data-service:3020
             - name: SIMSERVICE_RABBITMQ_ENABLED
-              value: true
+              value: 'true'
             - name: SIMSERVICE_RABBITMQ_LOGIN
               value: 'terarium'
             - name: SIMSERVICE_RABBITMQ_PASSWORD

--- a/kubernetes/overlays/prod/base/services/simulation-service/simulation-service-deployment.yaml
+++ b/kubernetes/overlays/prod/base/services/simulation-service/simulation-service-deployment.yaml
@@ -13,15 +13,15 @@ spec:
           env:
             - name: SIMSERVICE_TDS_URL
               value: http://data-service:3020
-            - name: SIMSERVICE_RABBITMQ_ENABLED
+            - name: RABBITMQ_ENABLED
               value: true
-            - name: SIMSERVICE_RABBITMQ_LOGIN
+            - name: RABBITMQ_LOGIN
               value: 'terarium'
-            - name: SIMSERVICE_RABBITMQ_PASSWORD
+            - name: RABBITMQ_PASSWORD
               value: 'terarium123'
-            - name: SIMSERVICE_RABBITMQ_ROUTE
+            - name: RABBITMQ_ROUTE
               value: 'sciml-queue'
-            - name: SIMSERVICE_RABBITMQ_HOST
+            - name: RABBITMQ_HOST
               value: 'message-queue'
-            - name: SIMSERVICE_RABBITMQ_PORT
+            - name: RABBITMQ_PORT
               value: '5672'

--- a/kubernetes/overlays/prod/base/services/simulation-service/simulation-service-deployment.yaml
+++ b/kubernetes/overlays/prod/base/services/simulation-service/simulation-service-deployment.yaml
@@ -13,15 +13,15 @@ spec:
           env:
             - name: SIMSERVICE_TDS_URL
               value: http://data-service:3020
-            - name: RABBITMQ_ENABLED
+            - name: SIMSERVICE_RABBITMQ_ENABLED
               value: true
-            - name: RABBITMQ_LOGIN
+            - name: SIMSERVICE_RABBITMQ_LOGIN
               value: 'terarium'
-            - name: RABBITMQ_PASSWORD
+            - name: SIMSERVICE_RABBITMQ_PASSWORD
               value: 'terarium123'
-            - name: RABBITMQ_ROUTE
+            - name: SIMSERVICE_RABBITMQ_ROUTE
               value: 'sciml-queue'
-            - name: RABBITMQ_HOST
+            - name: SIMSERVICE_RABBITMQ_HOST
               value: 'message-queue'
-            - name: RABBITMQ_PORT
+            - name: SIMSERVICE_RABBITMQ_PORT
               value: '5672'


### PR DESCRIPTION
# messed up with the wrong env var names
