### PR TITLE
task: removing gateway admin keycloak from local dev

### DIFF
--- a/kubernetes/base/gateway/kustomization.yaml
+++ b/kubernetes/base/gateway/kustomization.yaml
@@ -2,10 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - gateway-admin-keycloak-deployment.yaml
-  - gateway-admin-keycloak-service.yaml
-  - gateway-admin-keycloak-ui-deployment.yaml
-  - gateway-admin-keycloak-ui-service.yaml
   - gateway-httpd-deployment.yaml
   - gateway-httpd-service.yaml
   - gateway-keycloak-deployment.yaml

--- a/kubernetes/overlays/dev/local/gateway/kustomization.yaml
+++ b/kubernetes/overlays/dev/local/gateway/kustomization.yaml
@@ -7,8 +7,6 @@ resources:
   - gateway-postgres-service.yaml
   - configmap/host.yaml
 patches:
-  - path: gateway-admin-keycloak-deployment.yaml
-  - path: gateway-admin-keycloak-service.yaml
   - path: gateway-httpd-deployment.yaml
   - path: gateway-httpd-service.yaml
   - path: gateway-keycloak-deployment.yaml


### PR DESCRIPTION
# Description

We never need to start gateway admin keycloak locally, unless for updates.