### PR TITLE
feat: add a local ta1 dashboard

### DIFF
--- a/kubernetes/overlays/prod/overlays/askem-production/services/knowledge-middleware/knowledge-middleware-report-cronjob.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-production/services/knowledge-middleware/knowledge-middleware-report-cronjob.yaml
@@ -54,6 +54,8 @@ spec:
                       key: chatgptkey
                 - name: MOCK_TA1
                   value: 'FALSE'
+                - name: LIVE_SERVICES
+                  value: 'TRUE'
           restartPolicy: OnFailure
           imagePullSecrets:
             - name: ghcr-cred

--- a/kubernetes/overlays/prod/overlays/askem-production/services/knowledge-middleware/knowledge-middleware-report-cronjob.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-production/services/knowledge-middleware/knowledge-middleware-report-cronjob.yaml
@@ -44,7 +44,7 @@ spec:
                 - name: SKEMA_RS_URL
                   value: 'http://skema-rs:4040'
                 - name: MIT_TR_URL
-                  value: 'http://mit-tr:4046'
+                  value: 'http://54.227.237.7'
                 - name: TA1_UNIFIED_URL
                   value: 'https://api.askem.lum.ai'
                 - name: OPENAI_API_KEY

--- a/kubernetes/overlays/prod/overlays/askem-production/services/knowledge-middleware/knowledge-middleware-report-local-cronjob.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-production/services/knowledge-middleware/knowledge-middleware-report-local-cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   name: knowledge-middleware-report
   namespace: terarium
 spec:
-  schedule: "0 13,18 * * 1-5" # at 9h and 14h ETC every weekday
+  schedule: "0 13 * * 1-5" # at 9h every weekday
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
   jobTemplate:

--- a/kubernetes/overlays/prod/overlays/askem-production/services/knowledge-middleware/knowledge-middleware-report-local-cronjob.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-production/services/knowledge-middleware/knowledge-middleware-report-local-cronjob.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: knowledge-middleware-report
+  namespace: terarium
+spec:
+  schedule: "0 13,18 * * 1-5" # at 9h and 14h ETC every weekday
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            software.uncharted.terarium: knowledge-middleware-report
+        spec:
+          containers:
+            - name: knowledge-middleware-report
+              image: knowledge-middleware-report-image
+              env:
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: data-service-s3
+                      key: aws-access-key-id
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: data-service-s3
+                      key: aws-secret-access-key
+                - name: AWS_REGION
+                  valueFrom:
+                    secretKeyRef:
+                      name: data-service-s3
+                      key: aws-region
+                - name: BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      name: data-service-s3
+                      key: aws-dataset-bucket
+                - name: TDS_URL
+                  value: 'http://data-service:3020'
+                - name: SKEMA_RS_URL
+                  value: 'http://skema-rs:4040'
+                - name: MIT_TR_URL
+                  value: 'http://mit-tr:4046'
+                - name: TA1_UNIFIED_URL
+                  value: 'https://api.askem.lum.ai'
+                - name: OPENAI_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: mit-proxy-secrets
+                      key: chatgptkey
+                - name: MOCK_TA1
+                  value: 'FALSE'
+          restartPolicy: OnFailure
+          imagePullSecrets:
+            - name: ghcr-cred

--- a/kubernetes/overlays/prod/overlays/askem-production/services/knowledge-middleware/knowledge-middleware-report-local-cronjob.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-production/services/knowledge-middleware/knowledge-middleware-report-local-cronjob.yaml
@@ -54,6 +54,8 @@ spec:
                       key: chatgptkey
                 - name: MOCK_TA1
                   value: 'FALSE'
+                - name: LIVE_SERVICES
+                  value: 'FALSE'
           restartPolicy: OnFailure
           imagePullSecrets:
             - name: ghcr-cred


### PR DESCRIPTION
# Description

Now we will run report for local TA1 services once a weekday, and live services twice per weekday.

See PRs
* https://github.com/DARPA-ASKEM/integration-dashboard/pull/4
* https://github.com/DARPA-ASKEM/knowledge-middleware/pull/71
