### PR TITLE
feat: spicedb grpc ingress

### DIFF
--- a/kubernetes/base/services/spicedb/spicedb-grpc-service.yaml
+++ b/kubernetes/base/services/spicedb/spicedb-grpc-service.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    alb.ingress.kubernetes.io/backend-protocol-version: GRPC #This tells AWS to send traffic from the ALB using HTTP2. Can use GRPC as well if you want to leverage GRPC specific features
+    alb.ingress.kubernetes.io/healthcheck-path: /
+    alb.ingress.kubernetes.io/success-codes: 0-99
+  labels:
+    app: spicegrpc
+  name: spicegrpc
+  namespace: terarium
+spec:
+  ports:
+  - name: "50051"
+    port: 50051
+    protocol: TCP
+    targetPort: 50051
+  selector:
+    software.uncharted.terarium/name: spicedb
+  sessionAffinity: None
+  type: NodePort

--- a/kubernetes/overlays/prod/overlays/askem-staging/ingress/spicedb-grpc-ingress.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-staging/ingress/spicedb-grpc-ingress.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    alb.ingress.kubernetes.io/backend-protocol-version: GRPC
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: instance
+  labels:
+    app: spicegrpc
+    environment: staging
+  name: spicegrpc
+  namespace: terarium
+spec:
+  ingressClassName: alb
+  rules:
+  - host: spicegrpc.staging.terarium.ai
+    http:
+      paths:
+      - backend:
+          service:
+            name: spicegrpc
+            port:
+              number: 50051
+        path: /
+        pathType: Prefix
+  tls:
+    - hosts:
+      - "spicegrpc.staging.terarium.ai"

--- a/kubernetes/overlays/prod/overlays/askem-staging/kustomization.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-staging/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - check-latest
   - ingress/private-web-ingress.yaml
   - ingress/private-web-ssl-ingress.yaml
+  - ingress/spicedb-grpc-ingress.yaml
   - secrets/secrets-adobe-api-key.yaml
   - secrets/secrets-beaker-creds.yaml
   - secrets/secrets-data-service-s3.yaml


### PR DESCRIPTION
# Description

- Seperate the GRPC ingress into a seperate lb with
- Add a matching grpc service with the right annotations (a kube service serving both http(s) and grpc endpoints confuses the load balancer controller and it doesn't seem to configure it properly in aws)

