### PR TITLE
task: use the public lumai image for skema-tr

### DIFF
--- a/kubernetes/overlays/prod/overlays/askem-production/kustomization.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-production/kustomization.yaml
@@ -104,7 +104,7 @@ images:
     newName: ghcr.io/darpa-askem/memgraph-platform
     newTag: '2.6.5-memgraph2.5.2-lab2.4.0-mage1.6'
   - name: skema-tr-image
-    newName: enoriega87/skema-webapp
+    newName: lumai/askem-skema-text-reading
     newTag: 'latest'
 
   # MIT

--- a/kubernetes/overlays/prod/overlays/askem-production/kustomization.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-production/kustomization.yaml
@@ -105,7 +105,7 @@ images:
     newTag: '2.6.5-memgraph2.5.2-lab2.4.0-mage1.6'
   - name: skema-tr-image
     newName: lumai/askem-skema-text-reading
-    newTag: 'latest'
+    newTag: 'sha-3ee47d1'
 
   # MIT
   - name: mit-proxy-image

--- a/kubernetes/overlays/prod/overlays/askem-staging/kustomization.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-staging/kustomization.yaml
@@ -117,7 +117,7 @@ images:
     newName: ghcr.io/darpa-askem/memgraph-platform
     newTag: '2.6.5-memgraph2.5.2-lab2.4.0-mage1.6'
   - name: skema-tr-image
-    newName: enoriega87/skema-webapp
+    newName: lumai/askem-skema-text-reading
     newTag: 'latest'
 
   # MIT

--- a/kubernetes/overlays/prod/overlays/askem-staging/kustomization.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-staging/kustomization.yaml
@@ -118,7 +118,7 @@ images:
     newTag: '2.6.5-memgraph2.5.2-lab2.4.0-mage1.6'
   - name: skema-tr-image
     newName: lumai/askem-skema-text-reading
-    newTag: 'latest'
+    newTag: 'sha-3ee47d1'
 
   # MIT
   - name: mit-proxy-image


### PR DESCRIPTION
# Description

Because it is not possible to build `skema-tr` on DARPA-ASKEM until after the Boston Hackathon, we will be using the public image.