### PR TITLE
task: create simulation-service-cronjob.yaml

### DIFF
--- a/kubernetes/overlays/prod/overlays/askem-production/services/simulation-service/simulation-service-cronjob.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-production/services/simulation-service/simulation-service-cronjob.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: simulation-service-report
+  namespace: terarium
+spec:
+  schedule: "0 14 * * 1-5" # at 10h ETC every weekday
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            software.uncharted.terarium: simulation-service-report
+        spec:
+          containers:
+            - name: simulation-service-report
+              image: docker:24.0.6
+              command:
+                - "/bin/sh"
+                - "-c"
+                - "docker-compose -f /path/to/your/docker-compose.yml up"


### PR DESCRIPTION
# Description

Goal is to run this repo docker-compose on k8 cronjob:
https://github.com/DARPA-ASKEM/simulation-integration

This command is enough: `docker compose run --build tests` then it can be stopped.
