### PR TITLE
bug: fix skema tr service to be nodeport

### DIFF
--- a/kubernetes/overlays/prod/overlays/askem-staging/kustomization.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-staging/kustomization.yaml
@@ -42,6 +42,7 @@ patches:
   - path: services/sciml-service/sciml-service-service.yaml
   - path: services/skema/skema-py-service.yaml
   - path: services/skema/skema-rs-service.yaml
+  - path: services/skema/skema-tr-service.yaml
   - path: services/skema/skema-tr-deployment.yaml
   - path: services/skema/skema-unified-service.yaml
 configMapGenerator:

--- a/kubernetes/overlays/prod/overlays/askem-staging/services/skema/skema-tr-service.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-staging/services/skema/skema-tr-service.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: skema-tr
+spec:
+  type: NodePort


### PR DESCRIPTION
# Description

Changes the skema tr service to be a nodeport for ingress to work properly

Resolves #(issue)
