### PR TITLE
Choose a different hmi-server

### DIFF
--- a/kubernetes/overlays/prod/overlays/askem-production/check-latest/images.txt
+++ b/kubernetes/overlays/prod/overlays/askem-production/check-latest/images.txt
@@ -1,7 +1,7 @@
 software.uncharted.terarium/name=beaker ghcr.io/darpa-askem/beaker-kernel:latest
 software.uncharted.terarium/name=data-service ghcr.io/darpa-askem/data-service:latest
 software.uncharted.terarium/name=hmi-client ghcr.io/darpa-askem/hmi-client:latest
-software.uncharted.terarium/name=hmi-server ghcr.io/darpa-askem/hmi-server:latest
+software.uncharted.terarium/name=hmi-server ghcr.io/darpa-askem/hmi-server:sha256:c2748b4aaa261a29c610a0493f0393a73979f7d8ff8e916b9e718bcb5c467dcc
 software.uncharted.terarium/name=knowledge-middleware-api ghcr.io/darpa-askem/knowledge-middleware-api:latest
 software.uncharted.terarium/name=knowledge-middleware-worker ghcr.io/darpa-askem/knowledge-middleware-worker:latest
 software.uncharted.terarium/name=mit-proxy ghcr.io/darpa-askem/mit-proxy:latest

--- a/kubernetes/overlays/prod/overlays/askem-production/kustomization.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-production/kustomization.yaml
@@ -60,7 +60,7 @@ images:
     newTag: 'latest'
   - name: hmi-server-image
     newName: ghcr.io/darpa-askem/hmi-server
-    newTag: 'latest'
+    newTag: 'sha256:c2748b4aaa261a29c610a0493f0393a73979f7d8ff8e916b9e718bcb5c467dcc'
   - name: spicedb-image
     newName: ghcr.io/authzed/spicedb
     newTag: 'v1.24.0'


### PR DESCRIPTION
Use a version of hmi-server that was created before the tds-migration merge.
