### PR TITLE
Enable Flyway on staging and production

### DIFF
--- a/kubernetes/overlays/prod/base/hmi/server/hmi-server-deployment.yaml
+++ b/kubernetes/overlays/prod/base/hmi/server/hmi-server-deployment.yaml
@@ -71,6 +71,8 @@ spec:
                   key: password
             - name: SPRING_DATASOURCE_INITIALIZE
               value: "true"
+            - name: SPRING_FLYWAY_ENABLED
+              value: "true"
             - name: SPRING_JPA_HIBERNATE_DDL-AUTO
               value: "update"
             - name: SPRING_RABBITMQ_ADDRESSES


### PR DESCRIPTION
flyway is disabled by default to avoid accidental updates from devs in an upcoming PR