### PR TITLE
fix nginx proxy buffer size

### DIFF
--- a/kubernetes/overlays/prod/overlays/askem-dev/ingress/private-web-ingress.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-dev/ingress/private-web-ingress.yaml
@@ -3,6 +3,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: private-web-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
+    nginx.ingress.kubernetes.io/proxy-buffers-number: "16"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "32k"
 spec:
   ingressClassName: nginx
   rules:

--- a/kubernetes/overlays/prod/overlays/askem-dev/ingress/private-web-ssl-ingress.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-dev/ingress/private-web-ssl-ingress.yaml
@@ -5,6 +5,11 @@ metadata:
   name: private-web-ssl-ingress
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: 'HTTPS'
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
+    nginx.ingress.kubernetes.io/proxy-buffers-number: "16"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "32k"
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
# Description

- I believe this will resolve the 502s we're seeing

Resolves:

```
2024/06/05 18:40:43 [error] 6198#6198: *20870713 upstream sent too big header while reading response header from upstream, client: 10.64.18.187, server: keycloak.dev.terarium.ai, request: "GET /realms/terarium/protocol/openid-connect/auth?client_id=app&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2F%3FconfigHash%3D17975ac7&response_type=code&scope=openid+profile&state=af511483dab9438f8beff8aa04475dbf&code_challenge=U58qWvfW-Z_liFrueCQNpIO5OLQ5zNZMumXpiZoSHUE&code_challenge_method=S256&response_mode=query HTTP/1.0", upstream: "https://10.244.4.112:8443/realms/terarium/protocol/openid-connect/auth?client_id=app&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2F%3FconfigHash%3D17975ac7&response_type=code&scope=openid+profile&state=af511483dab9438f8beff8aa04475dbf&code_challenge=U58qWvfW-Z_liFrueCQNpIO5OLQ5zNZMumXpiZoSHUE&code_challenge_method=S256&response_mode=query", host: "keycloak.dev.terarium.ai", referrer: "http://localhost:8080/"

```
