### PR TITLE
Fix Cosmos Health Check

### DIFF
--- a/kubernetes/base/services/cosmos/cosmos-deployment.yaml
+++ b/kubernetes/base/services/cosmos/cosmos-deployment.yaml
@@ -27,21 +27,15 @@ spec:
           ports:
             - containerPort: 8089
           readinessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: 8089
-              scheme: HTTP
-            initialDelaySeconds: 5
+            initialDelaySeconds: 15
             periodSeconds: 10
-            timeoutSeconds: 5
           livenessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: 8089
-              scheme: HTTP
             initialDelaySeconds: 5
             periodSeconds: 10
-            timeoutSeconds: 5
           resources: {}
       imagePullSecrets:
         - name: ghcr-cred


### PR DESCRIPTION
# Description

HTTP Checks are only valid for 200..<400 and therefore 404s fail.  TCP checks pass if the server responds at all

Resolves #(issue)
