### PR TITLE
move these services back to nodeports

### DIFF
--- a/kubernetes/overlays/prod/overlays/askem-dev/services/beaker/beaker-service.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-dev/services/beaker/beaker-service.yaml
@@ -4,4 +4,4 @@ kind: Service
 metadata:
   name: beaker
 spec:
-  type: ClusterIP
+  type: NodePort

--- a/kubernetes/overlays/prod/overlays/askem-dev/services/climate-data/climate-data-service.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-dev/services/climate-data/climate-data-service.yaml
@@ -4,4 +4,4 @@ kind: Service
 metadata:
   name: climate-data
 spec:
-  type: ClusterIP
+  type: NodePort

--- a/kubernetes/overlays/prod/overlays/askem-dev/services/cosmos/cosmos-service.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-dev/services/cosmos/cosmos-service.yaml
@@ -4,4 +4,4 @@ kind: Service
 metadata:
   name: cosmos
 spec:
-  type: ClusterIP
+  type: NodePort

--- a/kubernetes/overlays/prod/overlays/askem-dev/services/data-service/data-service-graphdb-service.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-dev/services/data-service/data-service-graphdb-service.yaml
@@ -4,4 +4,4 @@ kind: Service
 metadata:
   name: data-service-graphdb
 spec:
-  type: ClusterIP
+  type: NodePort

--- a/kubernetes/overlays/prod/overlays/askem-dev/services/mit/mit-tr-service.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-dev/services/mit/mit-tr-service.yaml
@@ -4,4 +4,4 @@ kind: Service
 metadata:
   name: mit-tr
 spec:
-  type: ClusterIP
+  type: NodePort

--- a/kubernetes/overlays/prod/overlays/askem-dev/services/pyciemss-service/pyciemss-api-service.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-dev/services/pyciemss-service/pyciemss-api-service.yaml
@@ -4,4 +4,4 @@ kind: Service
 metadata:
   name: pyciemss-api
 spec:
-  type: ClusterIP
+  type: NodePort

--- a/kubernetes/overlays/prod/overlays/askem-dev/services/redis/redis-service.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-dev/services/redis/redis-service.yaml
@@ -4,4 +4,4 @@ kind: Service
 metadata:
   name: redis
 spec:
-  type: ClusterIP
+  type: NodePort

--- a/kubernetes/overlays/prod/overlays/askem-dev/services/sciml-service/sciml-service-service.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-dev/services/sciml-service/sciml-service-service.yaml
@@ -4,4 +4,4 @@ kind: Service
 metadata:
   name: sciml-service
 spec:
-  type: ClusterIP
+  type: NodePort

--- a/kubernetes/overlays/prod/overlays/askem-dev/services/skema/skema-rs-service.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-dev/services/skema/skema-rs-service.yaml
@@ -4,4 +4,4 @@ kind: Service
 metadata:
   name: skema-rs
 spec:
-  type: ClusterIP
+  type: NodePort

--- a/kubernetes/overlays/prod/overlays/askem-dev/services/skema/skema-text-reading-service.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-dev/services/skema/skema-text-reading-service.yaml
@@ -4,4 +4,4 @@ kind: Service
 metadata:
   name: skema-text-reading
 spec:
-  type: ClusterIP
+  type: NodePort

--- a/kubernetes/overlays/prod/overlays/askem-dev/services/skema/skema-unified-service.yaml
+++ b/kubernetes/overlays/prod/overlays/askem-dev/services/skema/skema-unified-service.yaml
@@ -4,4 +4,4 @@ kind: Service
 metadata:
   name: skema-unified
 spec:
-  type: ClusterIP
+  type: NodePort


### PR DESCRIPTION
# Description

- I moved these ClusterIPs while debugging the websocket stuff, moving these back to nodeports so we can access from our internal frontend.

